### PR TITLE
#27 알고리즘 문제풀이 - alirz-pixel 

### DIFF
--- a/alirz-pixel/BOJ/15900 나무 탈출.cpp
+++ b/alirz-pixel/BOJ/15900 나무 탈출.cpp
@@ -1,0 +1,70 @@
+#include <iostream>
+#include <vector>
+#include <queue>
+#include <stack>
+
+using namespace std;
+
+vector<vector<int>> tree;
+vector<int> path_legnth;
+stack<int> child;
+int n, cnt = 0;
+
+void bfs() {
+	queue<int> q;
+	vector<int> v(n);
+
+	q.push(0);
+	v[0] = true;
+
+	int depth = -1;
+	while (!q.empty()) {
+		int size = q.size();
+		depth++;
+
+		while (size--) {
+			int front = q.front();
+			q.pop();
+
+			for (auto i : tree[front]) {
+				if (v[i]) {
+					continue;
+				}
+
+				v[i] = true;
+
+				q.push(i);
+			}
+
+			if (front != 0 && tree[front].size() == 1) {
+				cnt += depth;
+			}
+		}
+	}
+}
+
+int main() {
+	cin.tie(0);
+	cout.tie(0);
+	ios::sync_with_stdio(false);
+
+	cin >> n;
+
+	path_legnth.assign(n, 0);
+
+	tree.assign(n, vector<int>());
+	for (int i = 0; i < n - 1; i++) {
+		int a, b;
+		cin >> a >> b;
+		a--; b--;
+
+		tree[a].push_back(b);
+		tree[b].push_back(a);
+	}
+
+	bfs();
+
+	cout << (cnt % 2 ? "Yes" : "No");
+
+	return 0;
+}

--- a/alirz-pixel/BOJ/2805 나무 자르기.cpp
+++ b/alirz-pixel/BOJ/2805 나무 자르기.cpp
@@ -1,0 +1,42 @@
+#include <algorithm>
+#include <iostream>
+#include <vector>
+
+using namespace std;
+
+int main() {
+	long long n, m;
+	cin >> n >> m;
+
+	vector<long long> tree(n);
+	for (auto& i : tree) {
+		cin >> i;
+	}
+
+	sort(tree.begin(), tree.end());
+
+	long long left = 0;
+	long long right = tree[tree.size() - 1];
+	long long mid = 0, ans = 0;
+	while (left <= right) {
+		mid = (left + right) / 2;
+		int idx = lower_bound(tree.begin(), tree.end(), mid) - tree.begin();
+
+		long long total = 0;
+		for (int i = idx; i < n; i++) {
+			total += tree[i] - mid;
+		}
+
+
+		if (m <= total) {
+			ans = mid;
+			left = mid + 1;
+		}
+		else {
+			right = mid - 1;
+		}
+	}
+	cout << ans;
+
+	return 0;
+}


### PR DESCRIPTION
## 1. [15900 나무 탈출](https://www.acmicpc.net/problem/15900)

### ✨ 문제 접근 방법 & 풀이법

루트노드부터 시작하여 `BFS` 탐색을 하면서
자식 노드에 도달한 경우, `변수 cnt`에 루트부터 현재 자식까지의 `depth`를 더해준다.

`BFS` 연산이 끝난 후, `cnt`가 짝수라면 "YES",  아니라면 "NO"를 출력한다.


### 🤦‍ 풀면서 어려웠던 점

처음 이 문제를 풀 때, `BFS`를 이용해 자식노드와 각 노드의 부모노드들을 저장을 했었다.
그리고 `BFS`연산이 끝난 후에 다시 자식부터 부모로 올라가면서 `depth`의 총합을 구했었는데,
이렇게 문제를 풀었더니 시간초과가 났다.
`

### 👀 궁금한 점

<br> <br>

## 2. [2805 나무 자르기](https://www.acmicpc.net/problem/2805)

### ✨ 문제 접근 방법 & 풀이법

이 문제는 `이분탐색` + `매개변수 탐색`의 문제로 
어디를 잘라야 환경을 지키면서 필요한 나무를 얻을 수 있는지에 대한 이분탐색 문제이다.

따라서 이분탐색의 `left` 값은 0(모든 나무 자르기), `right`값은 "입력으로 주어진 나무 높이의 최댓값"을 저장하고
`mid` 높이로 나무를 잘랐을 때, 얻을 수 있는 나무량이 `m`값 보다 크다면 왼쪽 영역 탐색, 작다면 오른쪽 영역 탐색

으로 진행하면서 환경을 고려하며 필요한 나무를 가져갈 수 있는 높이를 구하면 된다.

### 🤦‍ 풀면서 어려웠던 점

이분탐색의 `left`, `right`, `mid` 중에 어느 값이 답이 되는지가 헷갈렸다.
[이분 탐색 헷갈리지 않게 구현하기](https://www.acmicpc.net/blog/view/109)

### 👀 궁금한 점

